### PR TITLE
Add actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy to VPS
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.5.3
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Deploy code to VPS
+        run: |
+          ssh -o StrictHostKeyChecking=no nanami@160.251.234.58 "
+            cd /var/www/tech773.com/conoha-blog &&
+            git pull origin main &&
+            sudo systemctl restart apache2
+          "


### PR DESCRIPTION
ref: #5 

GitHubリポジトリの`main`ブランチに変更があるたびに自動的にVPSにデプロイされたサイトを更新するには、GitHub Actionsを使用して自動デプロイを設定することが一般的です。

### 手順

1. **GitHub Actionsを設定**
2. **VPSに公開鍵を配置**
3. **GitHubリポジトリにシークレットを追加**
4. **GitHub Actionsワークフローの作成**

### 1. GitHub Actionsを設定

GitHub Actionsを使用して、`main`ブランチに変更があるたびに自動的にVPSにデプロイします。

### 2. VPSに公開鍵を配置

まず、VPSにSSHで接続するためのSSHキーを作成します。

```bash
ssh-keygen -t rsa -b 4096 -C "your_email@example.com"
```

パスフレーズを入力しない場合は空でEnterキーを押します。この操作で、`~/.ssh/id_rsa`と`~/.ssh/id_rsa.pub`の2つのファイルが作成されます。

公開鍵の内容をコピーします。

```bash
cat ~/.ssh/id_rsa.pub
```

VPSにログインし、`~/.ssh/authorized_keys`ファイルに公開鍵を追加します。

```bash
echo "your_public_key_contents" >> ~/.ssh/authorized_keys
```

### 3. GitHubリポジトリにシークレットを追加

GitHubリポジトリの設定に移動し、`Settings` > `Secrets and variables` > `Actions` > `New repository secret`を選択します。以下のシークレットを追加します。

- `SSH_PRIVATE_KEY`：`~/.ssh/id_rsa`の内容を追加します。

### 4. GitHub Actionsワークフローの作成

GitHubリポジトリのルートに`.github/workflows/deploy.yml`という名前の新しいファイルを作成します。以下のように設定します。

```yaml
name: Deploy to VPS

on:
  push:
    branches:
      - main

jobs:
  deploy:
    runs-on: ubuntu-latest

    steps:
      - name: Checkout code
        uses: actions/checkout@v2

      - name: Setup SSH
        uses: webfactory/ssh-agent@v0.5.3
        with:
          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}

      - name: Deploy code to VPS
        run: |
          ssh -o StrictHostKeyChecking=no user@your_vps_ip_address "
            cd /var/www/tech773.com &&
            git pull origin main &&
            sudo systemctl restart apache2
          "
```

ここで、
- `user` はVPSのユーザー名に置き換えます。
- `your_vps_ip_address` はVPSのIPアドレスに置き換えます。
- `cd /var/www/tech773.com` はリポジトリをクローンしたディレクトリに置き換えます。

### 5. デプロイの確認

これで、`main`ブランチに変更がプッシュされるたびに、GitHub Actionsが自動的にVPSに接続し、リポジトリをプルしてサイトを更新し、Apacheを再起動するように設定されました。

サイトの変更をテストするために、`main`ブランチにコミットをプッシュして動作を確認してください。

問題が発生した場合は、GitHub Actionsのログを確認して、どのステップでエラーが発生しているかを特定し、それに基づいて修正を行ってください。